### PR TITLE
add 2024 ideas list

### DIFF
--- a/2024/ideas-list.md
+++ b/2024/ideas-list.md
@@ -1,0 +1,8 @@
+# Project Ideas for 2024
+
+IOOS DMAC community's project ideas list for [Google Summer of Code 2024](https://summerofcode.withgoogle.com/programs/2024).
+
+
+|**Project** |**Description**|**Links**| **Hours** |
+|------------|---------------|---------|-----------|
+|[gliderpy](https://github.com/ioos/gliderpy) | gliderpy is a thin wrapper around erddapy with custom methods and plotting functionality to browse, fetch, and plot glider data. | [ioos/gliderpy#61](https://github.com/ioos/gliderpy/issues/61) | 175 hours |


### PR DESCRIPTION
Not ready for merging yet. I want to add 1 new project idea first as an example. It will be a re vised version of the gliderpy project.

PS: Maybe we should ask folks to create their project ideas as issues in this repo. That way we can manage last minutes edits and we will keep a history of projects. What do you think?