### PR TITLE
Updates for 2025:

### DIFF
--- a/.github/ISSUE_TEMPLATE/gsoc-project-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/gsoc-project-proposal.yml
@@ -39,6 +39,14 @@ body:
       placeholder: Mentor Name (@somegithubhandlethatsurelynoonealreadyhas), Mentor Name 2 (@someothergithubhandlethatsurelynoonealreadyhas)
     validations:
       required: true
+  - type: input
+    id: mentor-email
+    attributes:
+      label: Mentor Contact Email(s)
+      description: Include mentor email addresses as a comma-separated list (minimum of one email address applicants can contact with questions or to discuss their project proposal/ideas)
+      placeholder: gsoc.mentor@organization.org, gsoc.mentor2@secondaryorg.org
+    validations:
+      required: true
   - type: dropdown
     id: size
     attributes:

--- a/contributor-guidance.md
+++ b/contributor-guidance.md
@@ -2,11 +2,21 @@
 
 ## Getting Started
 
-The best thing to help your application is to contact the organization and mentors you want to work with early.  You can introduce yourself in an issue with, or perhaps send a small PR to the project.
+If IOOS is included as a GSoC mentoring organization for the year (typically announced in late February per the [GSoC program timeline](https://developers.google.com/open-source/gsoc/timeline), we invite interested contributors to apply to and of the projects listed in our project ideas list, linked from the [README](https://github.com/ioos/gsoc/blob/main/README.md). 
 
-[The opensource guide](https://opensource.guide/how-to-contribute/) has a good introduction how to start contributing to open source projects.
+If you find a a project you feel you can tackle, reach out to the mentors to start a conversation about the project and to share your ideas.  
 
-## Do I have the experience to apply?
+Some prospective contributors comment in the project idea GitHub issue directly, and this is OK to do to begin a dialog with mentors, however we discourage you from sharing any detailed ideas that you have in GitHub issue comments, as there's always a risk of plagiarism by other applicants in an open forum such as GitHub.  
+
+We ask mentors to include an email address for at least one mentor in each project idea; please instead reach out via email to mentor(s) to discuss any specific ideas you're considering or plans you have for your proposal.
+
+Additionally, if the project idea you're intersted in includes links to existing background issues in the project's code repository, you can read up on those, and, if you're able to, submit a PR to demonstrate your ability.  Some projects might tag open issues as suitable for GSoC as a way to identify more manageable issues for potential new contributors to address.  Feel free to tackle any of those if you are able as they'll allow mentors to assess your ability firsthand. 
+
+**Further Background:** 
+* [The opensource guide](https://opensource.guide/how-to-contribute/) has a good introduction how to start contributing to open source projects.
+
+
+### Do I have the experience to apply?
 
 The answer is generally: **Yes**.
 Note that our organization values creativity, intelligence and enthusiasm above specific knowledge of the libraries or algorithms we use.
@@ -14,11 +24,30 @@ We think that a motivated students who are willing to learn are more valuable th
 
 The [GSoC Guide](https://google.github.io/gsocguides/student/am-i-good-enough#) gives a good overview of this part for GSoC.
 
-## What We Expect From Students
+## Applying to Google Summer of Code & IOOS
+
+To get an idea for the IOOS Data Management and Cyberinfrastructure (DMAC) community (the overarching community from which most of our GSoC mentors and projects are drawn from), visit the 'ioos_tech' Google Group: https://groups.google.com/g/ioos_tech.
+
+### Proposal template
+
+We provide a an application/proposal template (in markdown) you can use as a reference or adapt for your personal application:
+
+**https://github.com/ioos/gsoc/blob/main/proposal-template.md**  
+
+Please include at a minimum each section in the proposal template in your application.  It is fine to reformat or reorder sections, and/or to submit an application in PDF format with diagrams, images, or code examples.  A complete application should include information for all of the sections and should have all of the placeholder information filled in.
+
+### What makes a good GSoC proposal?
+
+An ideal GSoC proposal should include the following:
+1. A detailed, descriptive title
+2. Personal Information, including contact info, timezone
+3. Link to a **code contribution**, such as a PR, you've made previously
+4. Full description of your proposed project, including timeline and planned deliverables (see the [proposal-template.md](https://github.com/ioos/gsoc/blob/main/proposal-template.md) for a recommended format)
+5. Your schedule during the GSoC period and any prior committments that might affect your availability (school exams, other work committments, travel, etc)
 
 ### During the application phase
 
-We usually favor students that show regular communication with mentors during the application period and are able to demonstrate a clear understanding of the challenge proposed in the project idea within their application.  In some cases, mentors may include existing GitHub issues or other references within their code that students can use to both understand the software and, in some cases, demonstrate they have a good chance to succeed in addressing the problem presented in the project idea.  
+We usually favor students that show regular communication with mentors during the application period and are able to demonstrate a clear understanding of the challenge proposed in the project idea within their proposal.  In some cases, mentors may include existing GitHub issues or other references within their code that students can use to both understand the software and, in some cases, demonstrate they have a good chance to succeed in addressing the problem presented in the project idea.  
 
 *These tips are here to help with your application. They are not required.*
 
@@ -33,3 +62,7 @@ We usually favor students that show regular communication with mentors during th
 - Did you continue communication until accepted students are announced?
 - Do you have time for GSoC? This is a paid job! State that you have time in your motivation letter, and list other commitments!
 - Does you application describe what motivates you to work on this project, and, how your involvement in GSoC and this project in particular furthers your career goals?
+
+### Submitting your application
+
+Submit your completed application to the Google Summer of Code website directly, following all of the guidelines.  This is the only way an applications will be accepted for GSoC.

--- a/proposal-template.md
+++ b/proposal-template.md
@@ -1,4 +1,26 @@
+
+An ideal GSoC proposal should include the following:
+1. A detailed, descriptive title
+2. Personal Information, including contact info, timezone
+3. Link to a **code contribution**, such as a PR, you've made previously
+4. Full description of your proposed project, including timeline and planned deliverables
+5. Your schedule during the GSoC period and any prior committments that might affect your availability (school exams, other work committments, travel, etc)
+
+Example GSoC proposal template:
+
+
 #  Title 
+
+## Personal Info
+1. Name 
+2. Contact Info (email, phone, etc.)
+3. Country, Timezone
+4. GitHub handle, LinkedIn or other professional profile
+5. School/University, concentration & expected graduation date
+6. Link to a resume (if you want)
+
+## About Me
+Short introduction to you and what your interests and goals are, both with GSoC and otherwise.  What are your goals for participating in GSoC in relation to your career?
 
 ## Abstract
 
@@ -7,10 +29,18 @@ Please **DO NOT** copy the project idea text here!
 
 ## Why this project?
 
-Why you want to do this GSoC project and our organizaiton?
+What interests you in this GSoC project and our organization?
 Note that this part is **very** important to show your motivation!
 
-## Technical Details
+## Prior Development Experience
+
+Do you have code on GitHub?  Share your prior development experience that qualifies you for GSoC and for the project you're applying for.  
+List examples of your previous code contributions: to other open source projects, personal projects, or coding projects for academic studies that are publicly-visible.  
+If you've already submitted code in the form of a PR to the project or organization that you're applying for for GSoC, link to that here to ensure mentors make the connection with your application!
+
+## Project Details
+
+### Technical Description
 
 More detailed description of your project.
 **Should** include all technical details of the projects for example:
@@ -20,50 +50,54 @@ More detailed description of your project.
 -  links to literature you used during the research,
 -  etc.
 
-Here it is important to show if you had previous conversations with your mentors.
+For this section, it is important to show if you had previous conversations with your mentors and have a sufficient understanding of the problem and a plan to address it during your project.
 
-## Development Experience
-
-Do you have code on GitHub?
-Can you show previous contributions to other projects?
-Did you do other code related projects or university courses?
-
-## Schedule of Deliverables
-
-Here you should list your milestones.
-This list is a start based on the phases of GSoC.
-You can/should add more details for each phase by breaking it down into weeks or set specific targets for each phase.
-Each target should be split into sub task with a time estimate.
-
-### **Community Bonding Period**
+### Community Bonding Period
 
 This phase is to get to know the community better and to prepare to start working on your project once the coding period begins.
 Check that your work environment is set up, and that you can access all the necessary code, data, or other prerequisites for your project.
 This time should also be used to discuss your project in more detail with your mentors and, with their assistance, introduce it to the broader developer community. 
 
-IOOS offers several options for you to engage with our developer and data manager community (see details in the [README](https://github.com/ioos/gsoc/blob/main/README.md)).  Please consider joining one of our virtual communication forums during the community bonding periord, or, if possible, participating in the [2024 IOOS Code Sprint](https://ioos.github.io/ioos-code-sprint/2024/) (virtual attendance available).  
+Describe what you plan to do during the community bonding period and how you'd like to communicate with your potential mentors during this time, and anything you'd ask from your mentors in the way of support during this period to get you and your project up to speed for the coding period.
 
-### **Phase 1**
+### Schedule of Deliverables
 
-Deliverables
+Here you should list your planned activities for the coding period, ideally on a weekly basis, and any specific milestones you plan to work towards in the schedule.  You can break down the coding period into different periods if you prefer (e.g. every two weeks), provided that you set specific targets for each phase and describe them clearly. Each target should be split into sub tasks with time estimates.
 
-### **Phase 2**
+#### **Phase 1**
+* **Week 1**
+* **Week 2**
+* **Week 3**
+* **Week 4**
+* **Week 5**
+* **Week 6**
 
-Deliverables
+Mid-point: List deliverables at the mid-way point, in addition to any specified during the week-by-week work breakdown above..  
 
-### **Final Week**
+#### **Phase 2**
+* **Week 7**
+* **Week 8**
+* **Week 9**
+* **Week 10**
+* **Week 11**  *Note: GSoC requires a final write up is submitted that your mentors will review in order to evaluate your work.  It's strongly advised that you share your writeup with your mentors prior to the due date so they can give feedback.  Consider planning to finish most of your coding by this week to ensure it can be merged/accepted and to focus on writing the report.*
+* **Week 12**
 
-At this stage you should finish up your project, and make sure that you have code submitted to your organization.
+#### **Final Week**
+End of the standard GSoC coding period.  List the final planned deliverables for your project here.
 
-*Note:* We require any accepted student projects to produce a final writeup summarizing your work.  Ideally, this can be posted directly on GitHub in markdown (.md) format on either a student's fork of a code repository, or in some cases in the source repository itself.  Other options include posting a blog post to a site such as Medium, or similar, where content is likely to remain available for future reference.  See our past GSoC project results pages from [2021](https://github.com/ioos/gsoc/blob/main/2021/project-results.md) and [2022](https://github.com/ioos/gsoc/blob/main/2022/project-results.md) for examples of student writeups.  
+At this stage your project should be completed and your code should already have been submitted to your organization, final report written, reviewed, and submitted via the GSoC website.  
 
-## Additional Background
+_**Please Note:** We ask our GSoC contributors to produce a final writeup summarizing their work prior to completion of GSoC.  This can often be based on your final report or, if you prefer, can be a more narrative-style summary of your experience with GSoC (lessons learned, challenges, highlights, etc).  The writeup should be posted either on a blogging platform where links tend to persist reliably (e.g. Medium, Hashnode, ?), or, if preferred, directly as a markdown-formatted GitHub gist.  Please avoid personal GitHub Pages sites as we've found those to be less persistent (see our previous year's contributors' posts for dead link examples).  See IOOS' 2024 GSoC [project results page](https://github.com/ioos/gsoc/blob/main/2024/project-results.md) for example contributor writeups._
 
-Please also provide brief answers to the following questions: 
-* what are your goals for participating in GSoC in relation to your career or future studies?
-* what is your preferred method to communicate with your project mentors during the coding period (virtual check-in meetings, Slack, GitHub issue, email)?
-* is there anything your mentors should know about your work schedule or studies during GSoC to ensure they can be most effective in supporting you?
+## Additional Background/Logistics
+
+Please provide brief answers to the following questions: 
+* What is your preferred method to communicate with your project mentors during GSoC (community bonding period & coding period).  What formats are you able to use: virtual check-in meetings, Slack, GitHub issue, email?
+* Is there anything your mentors should know about your previous committments, other work schedule, or studies during GSoC that you'll need to work around during GSoC?  How do you plan to honor these committments while also completing your GSoC project?  Please provide this info to ensure your mentors are aware and can be most effective in supporting you.
+* 
 
 ## Appendix
 
 *Optional*: Please add any additional content or references/links that support your application.
+
+*Note: Portions of this application template were borrowed from the excellent template provided the Python GSoC organization: https://github.com/python-gsoc/python-gsoc.github.io/blob/main/ApplicationTemplate.md.  Thanks!*


### PR DESCRIPTION
* More detail in contributor-guidance.md
* Improved proposal-template.md to match prior applications & other template examples
* Updated project idea form to require mentor emails

I spent some time updating our contributor materials (and borrowing shamelessly from the Python GSoC materials at: https://python-gsoc.org/index.html#apply)  Acknowledgement added at the end of the proposal-template.md to the Python one.  

Pls take a look.  Even if we aren't accepted for 2025, this should help down the road.

One thing I realized while writing this: we should really ask mentors to include at least one email address applicants can contact them at for any private discussions they don't want to/shouldn't have out in the open on GitHub.  For this year, if we're accepted, we'll have to get that from all the mentors and update the ideas list for each idea issue.