### PR TITLE
Add mentor guidance for GSoC participation

### DIFF
--- a/mentor-guidance.md
+++ b/mentor-guidance.md
@@ -1,52 +1,88 @@
-# Mentor Guide
+# IOOS' GSoC Mentor Guide
 
-## Getting Started
+## Mentor Overview
 
-If IOOS is included as a GSoC mentoring organization for the year (typically announced in late February per the [GSoC program timeline](https://developers.google.com/open-source/gsoc/timeline), we invite interested mentors to propose project ideas using our [GSoC Project Issue Template](https://github.com/ioos/gsoc/issues/new?template=gsoc-project-proposal.yml). 
+Interested in mentoring a GSoC contributor this year?  
 
-The process for GSoC follows this rough outline:
-1. **Mentor** submits a project idea to the IOOS Organization following the guidance here.
-1. IOOS reviews the list of project ideas to determine how many slots to request.
-1. IOOS submits an application to Google with the list of proposed project ideas.
-1. Google reviews the organization application and notifies which ogranizations have been accepted and what number of slots the organization has been granted.
-1. If accepted, potential GSoC contributors will engage with the project ideas via GitHub issues.
-1. **Mentors** collaborate with potential contributors and evaluate their suitability for the project. See [evaluating contributors](#evaluating-project-contributors).
-1. Contributors submit applications to IOOS.
-1. IOOS ranks applications and submits them to Google.
-1. Google announces accepted projects.
-1. If accepted, coding runs for four months (typically May - August). **Mentors** support the project throughout the coding period.
-1. Contributors submit mid-term and final summaries of their work.
-1. Mid-term and final evaluations are submitted by the Mentor. These are breakpoints at which a project can be failed. See [Warning Signs](https://google.github.io/gsocguides/mentor/warning-signs) for more details on warning signs to look out for in a project.
+IOOS needs you - a new or returning mentor from the DMAC community - to submit your project ideas and support our application as a GSoC mentoring organization before the Org application deadline - **in early February** - in order to re-apply to this year's GSoC. 
 
-**Further Background:** 
-* [Google Summer of Code Guide - Mentor](https://google.github.io/gsocguides/mentor/) has great information about being a GSoC mentor.
+Read on for info about: 
+* [Proposing a GSoC project to IOOS](#),
+* IOOS' [expectations for GSoC mentors](#),
+* the [GSoC timeline](#) from a mentor's perspective,
+* tips for [good GSoC project ideas](#), and more.  
 
-### Do I have the experience to be a mentor?
+__**Submit your project idea:**__ please check out the [README](https://github.com/ioos/gsoc) for the latest information on this year's program and links to submit a project idea. 
 
-The answer is generally: **Yes**.
-Note that our organization values creativity, intelligence and enthusiasm above specific knowledge of the libraries or algorithms we use.
-
-The [GSoC Guide](https://google.github.io/gsocguides/mentor/what-makes-a-good-mentor) gives a good overview of what makes a good mentor.
 
 ## Proposing a project to Google Summer of Code & IOOS
 
 To get an idea for the previous projects that have been proposed for the IOOS Organization, see the previous year's project ideas and results in the [README](https://github.com/ioos/gsoc#ioos-and-google-summer-of-code).
 
-### What makes a good GSoC project?
+_What makes a good GSoC project idea (IOOS' perspective):_
+
+The most successful GSoC project ideas involve ***previously-existing, open source software packages*** that might benefit from the addition of a new feature, capability or related application or tool, resolving a thorny bug that you, and a package maintainer, have the expertise to assist another developer in resolving, or the addition of use-case examples that involve developing and publishing new code (e.g. Jupyter notebook software use case demonstrations). 
+
+**Draft or initial project ideas are OK.**  Project ideas need to include basic background information (project description and purpose, expected skills, mentor names), but it’s a fairly easy lift to propose a new project.  If IOOS is accepted for the 2025 program, project ideas can be further refined or improved over the next month until the contributor application period begins in March. 
+
+_What GSoC is not suitable for:_ 
+
+GSoC is not the right program if you're looking to hire a summer intern for 'free' to lessen your to do list!  It is fundamentally about teaching aspiring developers/coders how to write code and contribute to open source software.  Time committment as a mentor to work with your contributor, review code, provide feedback/guidance, and to meet on a regular schedule to review progress is essential.  
+
+GSoC is also not suitable for developing documentation about your code, or to start a new projects without pre-existing, publicly-available, open source code.  
+
+The program is designed to teach contributors about your software and project maintainer community (even if only yourself), how to write better code, and to learn about the process of open source software development itself, including interacting with existing contributors in GitHub or other public channels.  As such, a pre-existing open source code base is required.
+
+
+## What is Expected of Mentors?
+IOOS as a GSoC mentoring organization values creativity, intelligence and enthusiasm above specific knowledge of the libraries or algorithms we use.  Please reach out to us if you have questions about whether your project/project idea is suitable for inclusion.  
+
+Google has a great article about [What Makes a Good GSoC Mentor?](https://google.github.io/gsocguides/mentor/what-makes-a-good-mentor.html) and futher details on GSoC mentoring in the full [Mentor Guide]([url](https://google.github.io/gsocguides/mentor/)). 
+
+If you are considering submitting a project idea to mentor for IOOS, we highly recommend starting there. Reading the guide will ensure:
+* f you know how the program works,
+* you know the level of committment typically expected of mentors,
+* you're aware of Google's advice and guidance for how best to select a contributor for your project and know some things to watch out for/be aware of in evaluating GSoC contributors/applications,
+* you know what past mentors and GSoC administrators find most essential for a successful mentoring experience during the summer coding period.
+
+
+## GSoC Mentor Timeline
+
+The GSoC timeline, from a mentor's persepective, is as follows:
+1. **Mentor** submits a project idea to the IOOS Organization following the guidance here _(Jan - early Feb)_
+1. IOOS reviews submitted project ideas, provides feedback to prospective mentors, and creates an 'Project Ideas List' of this year's potential projects
+1. IOOS submits our ideas list as part a GSoC mentoring organization application to Google _(early Feb)_ 
+1. Google reviews org applications and announces accepted mentoring orgs _(Feb)_ 
+1. If IOOS is accepted this year, potential GSoC contributors will engage with **mentors** via the project ideas list and associated GitHub issues _(mid-Feb - mid-Mar)_
+1. **Mentors** collaborate with potential contributors and evaluate their suitability for the project. See [evaluating contributors](#evaluating-project-contributors)  _(mid-Feb - mid-Mar)_
+1. Contributors submit applications to IOOS. _(end of Mar)_
+1. **Mentors** review applications submitted for their project ideas _(early - mid Apr)_
+1. **Mentors** select either the best application for their idea to put forward to IOOS for ranking, or select none if appropriate _(mid Apr)_
+1. IOOS ranks all selected applications and submits a ranked list of projects to Google for funding
+1. Google announces the number of 'slots', or accepted projects, for IOOS for the year _(end of Apr)_
+1. **Mentors** whose projects have been granted a slot begin working with their contributors during the 'Community Bonding Period' _(May)_
+1. **Mentors** and contributors work together on their projects during the summer Coding Period (typical runs for four months ending in August) _(Jun - Aug)_ 
+1. Contributors submit mid-term and final summaries of their work.
+1. **Mentors** submit mid-term and final evaluations of their contributors' work. These are breakpoints at which a project can be failed. See [Warning Signs](https://google.github.io/gsocguides/mentor/warning-signs) for more details on warning signs to look out for in a project.
+
+
+## What makes a good GSoC project?
 
 An ideal GSoC project idea should consider the following:
 1. Follow the [GSoC Project Issue Template](https://github.com/ioos/gsoc/issues/new?template=gsoc-project-proposal.yml)
 1. Projects should take ~90 hour, ~175 hours or ~350 hours for GSoC contributors to complete.
 1. Don’t be vague about the ideas. Be sure to write a few sentences describing what you need accomplished and not just an overall theoretical version of what you might want.
 1. Briefly describe a general high-level need, and the motivation behind that need. Keeping the scope modest helps encourage more applicants, while adding a “stretch” goal to the project description may encourage stronger GSoC contributors to take on the challenge of meeting it.
+1. Include a contributor evaluation challenge or test - this will help you to determine if an applicant's technical skills align with your project 
 1. Don’t propose projects that neither you nor anyone else wants to mentor.
 
-### Evaluating project contributors
+
+## Evaluating project contributors
 
 We usually favor students that show regular communication with mentors during the application period and are able to demonstrate a clear understanding of the challenge proposed in the project idea within their proposal.  
 In some cases, mentors may include existing GitHub issues or other references within their code that students can use to both understand the software and, in some cases, demonstrate they have a good chance to succeed in addressing the problem presented in the project idea.  
 
-Engage with your GSoC contributor as early as possible. Integrate the GSoC contributor into your community and its communication channels. Make sure that communication with your GSoC contributor is frequent and regular.
+Engage with your GSoC contributor as early as possible, once accepted Orgs are announced and during the contributor applicaiton period _(mid Feb - Mar)_. Integrate the GSoC contributor into your community and its communication channels. Make sure that communication with your GSoC contributor is frequent and regular.
 
 *These tips are here to help with a mentors evaluation of a contributor. They are not required.*
 


### PR DESCRIPTION
This document serves as a guide for mentors participating in the Google Summer of Code (GSoC) with IOOS. It outlines the process for proposing projects, evaluating contributors, and provides resources for mentors.